### PR TITLE
Handle strings instead of MarkupStrings & Use Serilog

### DIFF
--- a/SimpleChatUi/Components/ChatMessage.razor
+++ b/SimpleChatUi/Components/ChatMessage.razor
@@ -1,6 +1,6 @@
 ﻿<div class="chat-message-container">
     <div class="chat-message-header">
-        <span class="bi @(IsUser ? "bi-person" : "bi-robot")" aria-hidden="true"></span>
+        <span class="bi @(IsUser ? "bi-person text-info" : "bi-robot text-success")" aria-hidden="true"></span>
         <label>@Entity</label>
     </div>
     <div class="chat-message @(IsUser ? "user-prompt" : "bot-answer")">@_messageMarkup</div>

--- a/SimpleChatUi/Components/ChatMessage.razor
+++ b/SimpleChatUi/Components/ChatMessage.razor
@@ -3,15 +3,17 @@
         <span class="bi @(IsUser ? "bi-person" : "bi-robot")" aria-hidden="true"></span>
         <label>@Entity</label>
     </div>
-    <div class="chat-message @(IsUser ? "user-prompt" : "bot-answer")">@Message</div>
+    <div class="chat-message @(IsUser ? "user-prompt" : "bot-answer")">@_messageMarkup</div>
 </div>
 
 @code {
+    private MarkupString _messageMarkup => (MarkupString)Message;
+
     [Parameter]
     public required string Entity { get; set; }
 
     [Parameter]
-    public required MarkupString Message { get; set; }
+    public required string Message { get; set; }
 
     [Parameter]
     public bool IsUser { get; set; }

--- a/SimpleChatUi/Components/ChatMessage.razor.css
+++ b/SimpleChatUi/Components/ChatMessage.razor.css
@@ -13,6 +13,8 @@
 
     .chat-message-header .bi {
         padding-right: 8px;
+        font-size: 24px;
+        margin-left: -8px;
     }
 
     .chat-message-header label {

--- a/SimpleChatUi/Components/Pages/Chat.razor.cs
+++ b/SimpleChatUi/Components/Pages/Chat.razor.cs
@@ -26,7 +26,7 @@ namespace SimpleChatUi.Components.Pages
             Bot,
         }
 
-        private readonly Dictionary<Sender, List<MarkupString>> _chatHistory = [];
+        private readonly Dictionary<Sender, List<string>> _chatHistory = [];
         private string _userMessage = string.Empty;
         private readonly MarkdownPipeline? _markdownPipeline;
 
@@ -111,7 +111,7 @@ namespace SimpleChatUi.Components.Pages
             {
                 Logger.LogInformation("Rendering final response for user {User}...", botEvent.TargetUser);
 
-                var fullAnswer = Markdig.Markdown.ToHtml(_chatHistory[Sender.Bot][lastAnswerIndex].Value, _markdownPipeline);
+                var fullAnswer = Markdig.Markdown.ToHtml(_chatHistory[Sender.Bot][lastAnswerIndex], _markdownPipeline);
                 _chatHistory[Sender.Bot][lastAnswerIndex] = new(fullAnswer);
 
                 await UpdateStateAsync();
@@ -152,6 +152,7 @@ namespace SimpleChatUi.Components.Pages
             if (_chatHistory.TryGetValue(sender, out var messages))
             {
                 _chatHistory[sender].Add(new(answer));
+                //messages.Add(new(answer));
             }
             else
             {
@@ -171,8 +172,8 @@ namespace SimpleChatUi.Components.Pages
 
         private IEnumerable<dynamic> BuildChatSequence()
         {
-            var userMessages = _chatHistory.TryGetValue(Sender.User, out List<MarkupString>? value) ? value : [];
-            var botMessages = _chatHistory.TryGetValue(Sender.Bot, out List<MarkupString>? botValue) ? botValue : [];
+            var userMessages = _chatHistory.TryGetValue(Sender.User, out List<string>? value) ? value : [];
+            var botMessages = _chatHistory.TryGetValue(Sender.Bot, out List<string>? botValue) ? botValue : [];
 
             var chatSequence = userMessages.Zip(botMessages.DefaultIfEmpty(), (user, bot) => new { UserMessage = user, BotMessage = bot });
             return chatSequence;
@@ -204,15 +205,15 @@ namespace SimpleChatUi.Components.Pages
                     else
                     {
                         // keep updating the last answer while streaming chunks
-                        var currentAnswer = _chatHistory[Sender.Bot].Last().Value;
+                        var currentAnswer = _chatHistory[Sender.Bot].Last();
                         currentAnswer += chunk;
-                        _chatHistory[Sender.Bot][_chatHistory[Sender.Bot].Count - 1] = new MarkupString(currentAnswer);
+                        _chatHistory[Sender.Bot][_chatHistory[Sender.Bot].Count - 1] = currentAnswer;
                     }
 
                     StateHasChanged();
                     await Task.Delay(rnd.Next(0, 1000));
 
-                    return;
+                    //return;
                 }
             }
 

--- a/SimpleChatUi/Components/Pages/Chat.razor.cs
+++ b/SimpleChatUi/Components/Pages/Chat.razor.cs
@@ -83,8 +83,7 @@ namespace SimpleChatUi.Components.Pages
         {
             if (!botEvent.TargetUser.Equals(_currentUser))
             {
-                var truncatedAnswer = botEvent.Answer[..Math.Min(botEvent.Answer.Length, 10)];
-                Logger.LogDebug("Received irrelevant answer ({TruncatedAnswer}) for {IrrelevantUser} while current chat is for {User}", truncatedAnswer, botEvent.TargetUser, _currentUser);
+                Logger.LogDebug("Received irrelevant answer for {IrrelevantUser} while current chat is for {User}", botEvent.TargetUser, _currentUser);
                 return;
             }
 
@@ -112,7 +111,7 @@ namespace SimpleChatUi.Components.Pages
                 Logger.LogInformation("Rendering final response for user {User}...", botEvent.TargetUser);
 
                 var fullAnswer = Markdig.Markdown.ToHtml(_chatHistory[Sender.Bot][lastAnswerIndex], _markdownPipeline);
-                _chatHistory[Sender.Bot][lastAnswerIndex] = new(fullAnswer);
+                _chatHistory[Sender.Bot][lastAnswerIndex] = fullAnswer;
 
                 await UpdateStateAsync();
 
@@ -151,12 +150,12 @@ namespace SimpleChatUi.Components.Pages
         {
             if (_chatHistory.TryGetValue(sender, out var messages))
             {
-                _chatHistory[sender].Add(new(answer));
-                //messages.Add(new(answer));
+                //_chatHistory[sender].Add(answer);
+                messages.Add(answer);
             }
             else
             {
-                _chatHistory.Add(sender, [new(answer)]);
+                _chatHistory.Add(sender, [answer]);
             }
 
             await UpdateStateAsync();

--- a/SimpleChatUi/Program.cs
+++ b/SimpleChatUi/Program.cs
@@ -1,3 +1,4 @@
+using Serilog;
 using SimpleChatUi.Components;
 using SimpleChatUi.Hubs;
 using SimpleChatUI.Hubs;
@@ -16,7 +17,9 @@ builder.Services.AddSignalR(options =>
 
 builder.Services.AddSingleton<ChatHubService>();
 
-builder.Services.AddLogging();
+// Serilog
+builder.Host.UseSerilog((context, configuration) =>
+    configuration.ReadFrom.Configuration(context.Configuration));
 
 var app = builder.Build();
 

--- a/SimpleChatUi/SimpleChatUi.csproj
+++ b/SimpleChatUi/SimpleChatUi.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Markdown.ColorCode" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.3" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
   </ItemGroup>
 
 </Project>

--- a/SimpleChatUi/appsettings.json
+++ b/SimpleChatUi/appsettings.json
@@ -5,5 +5,22 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": "Information",
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "encoding": "System.Text.Encoding::UTF8",
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Sixteen, Serilog.Sinks.Console"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName" ],
+    "Properties": {
+      "ApplicationName": "SimpleOpenAiService"
+    }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
- 📝 (`ChatMessage.razor`): update `ChatMessage` component to use `string` instead of `MarkupString` for `Message` parameter and implement `_messageMarkup` property
- 📝 (`Chat.razor.cs`): modify `_chatHistory` dictionary to store `List<string>` instead of `List<MarkupString>` in `Chat` component
- ✨ (Multiple files): refactor codebase to handle `strings` instead of `MarkupStrings` in chat-related components and services
- 🚀Use Serilog